### PR TITLE
Add support for aarch64 architecture

### DIFF
--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+ADD crux-arm-rootfs-3.4-aarch64.tar.xz /
+
+# Add default image command
+CMD ["/bin/bash"]

--- a/aarch64/crux-fetch.sh
+++ b/aarch64/crux-fetch.sh
@@ -1,0 +1,2 @@
+#fetching aarch64 rootfs 
+wget http://resources.crux-arm.nu/releases/3.4/crux-arm-rootfs-3.4-aarch64.tar.xz


### PR DESCRIPTION
The script has been added to fetch the rootfs for ```arm64v8```.
This script retrieves rootfs from ```http://resources.crux-arm.nu/releases/3.4/crux-arm-rootfs-3.4-aarch64.tar.xz```

The user needs to execute crux-fetch.sh to get rootfs for aarch64.
After this Docker build can be executed with rootfs and Dockerfile.
