### PR TITLE
Bump Crux to version 3.4

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -2,30 +2,41 @@
 
 set -e
 
-url=${1:-http://ftp.morpheus.net/pub/linux/crux/latest/iso/crux-3.1.iso}
-version=$(basename --suffix=.iso $url | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
+dpkgArch="$(uname -m)";
+	case "${dpkgArch##*-}" in
+	x86_64)
+		url=${1:-http://ftp.morpheus.net/pub/linux/crux/latest/iso/crux-3.4.iso}
+		version=$(basename --suffix=.iso $url | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
-docker build -t cruxbuild build
+		docker build -t cruxbuild build
 
-docker rm -f cruxbuild
+		docker rm -f cruxbuild
 
-docker run \
-	-i -t --privileged \
-	--name cruxbuild \
-	-e URL=${url} \
-	-v $(pwd)/media:/mnt/media \
-	cruxbuild
+		docker run \
+			-i -t --privileged \
+			--name cruxbuild \
+			-e URL=${url} \
+			-v $(pwd)/media:/mnt/media \
+			cruxbuild
 
-if $(git show-ref --verify --quiet refs/heads/${version}); then
-	git branch -D ${version}
-fi
+		if $(git show-ref --verify --quiet refs/heads/${version}); then
+			git branch -D ${version}
+		fi
 
-git checkout -b ${version} origin/dist
+		git checkout -b ${version} origin/dist
 
-docker cp cruxbuild:/build/rootfs.tar.xz .
-docker rm -f cruxbuild
+		docker cp cruxbuild:/build/rootfs.tar.xz .
+		docker rm -f cruxbuild
 
-git add rootfs.tar.xz
-git commit -m "${version}"
+		git add rootfs.tar.xz
+		git commit -m "${version}"
 
-docker build -t crux:${version} .
+		docker build -t crux:${version} .;;
+
+	aarch64)
+		$sh aarch64/crux-fetch.sh
+		$(mv crux-arm-rootfs-3.4-aarch64.tar.xz aarch64/)
+
+		docker build -t cruxbuild aarch64;;
+	esac;
+

--- a/test.sh
+++ b/test.sh
@@ -2,17 +2,27 @@
 
 set -e
 
-version=${1:-3.1}
+dpkgArch="$(uname -m)";
+	case "${dpkgArch##*-}" in
+	x86_64)
+		version=${1:-3.4}
 
-docker build -t cruxbuild build
+		docker build -t cruxbuild build
 
-docker run \
-	-i -t --privileged \
-	--name cruxbuild \
-	-e VERSION=${version} \
-	-v $(pwd)/media:/mnt/media \
-	cruxbuild
+		docker run \
+			-i -t --privileged \
+			--name cruxbuild \
+			-e VERSION=${version} \
+			-v $(pwd)/media:/mnt/media \
+			cruxbuild
 
-docker cp cruxbuild:/rootfs.tar.xz .
-docker import - test < rootfs.tar.xz
-docker rm -f cruxbuild
+		docker cp cruxbuild:/rootfs.tar.xz .
+		docker import - test < rootfs.tar.xz
+		docker rm -f cruxbuild;;
+
+	aarch64)
+		$sh aarch64/crux-fetch.sh
+		$(mv crux-arm-rootfs-3.4-aarch64.tar.xz aarch64/)
+
+		docker build -t cruxbuild aarch64;;
+	esac;


### PR DESCRIPTION
 - Crux is moved to 3.4 from 3.1
 - Scripts are modified to handle both AMD64 and AARCH64.

Signed-off-by: Odidev <odidev@puresoftware.com>